### PR TITLE
도메인 기반 커스텀 예외 추가

### DIFF
--- a/src/main/java/project/closet/exception/ClosetException.java
+++ b/src/main/java/project/closet/exception/ClosetException.java
@@ -1,0 +1,26 @@
+package project.closet.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+public abstract class ClosetException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private final Map<String, Object> details = new HashMap<>();
+
+    protected ClosetException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    protected ClosetException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+
+    public void addDetail(String key, Object value) {
+        this.details.put(key, value);
+    }
+}

--- a/src/main/java/project/closet/exception/ErrorCode.java
+++ b/src/main/java/project/closet/exception/ErrorCode.java
@@ -1,0 +1,19 @@
+package project.closet.exception;
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+    //DM
+    DM_NOT_FOUND("DM을 찾을 수 없습니다."),
+    //FEED
+    FEED_NOT_FOUND("피드를 찾을 수 없습니다."),
+
+    INVALID_REQUEST("잘못된 요청입니다."),
+    INTERNAL_ERROR("서버 내부 오류입니다.");
+
+    private final String message;
+
+    ErrorCode(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/project/closet/exception/ErrorResponse.java
+++ b/src/main/java/project/closet/exception/ErrorResponse.java
@@ -1,0 +1,36 @@
+package project.closet.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ErrorResponse {
+    private final String exceptionName;
+    private final String message;
+    private final Map<String, Object> details;
+    private final int status;
+
+
+    public ErrorResponse(ClosetException exception, int status) {
+        this(
+                exception.getClass().getSimpleName(),
+                exception.getMessage(),
+                exception.getDetails(),
+                status
+        );
+    }
+
+
+    public ErrorResponse(Exception exception, int status) {
+        this(
+                exception.getClass().getSimpleName(),
+                exception.getMessage(),
+                new HashMap<>(),
+                status
+        );
+    }
+}

--- a/src/main/java/project/closet/exception/GlobalExceptionHandler.java
+++ b/src/main/java/project/closet/exception/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package project.closet.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    //도메인에서 명시적으로 발생시킨 사용자 정의 예외
+    @ExceptionHandler(ClosetException.class)
+    public ResponseEntity<ErrorResponse> handleClosetException(ClosetException ex) {
+        HttpStatus status = mapToHttpStatus(ex.getErrorCode());
+        ErrorResponse response = new ErrorResponse(
+                ex.getClass().getSimpleName(),
+                ex.getMessage(),
+                ex.getDetails(),
+                status.value()
+        );
+        return ResponseEntity.status(status).body(response);
+    }
+
+    //모든 예상하지 못한 예외
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGeneric(Exception ex) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse(ex, HttpStatus.INTERNAL_SERVER_ERROR.value()));
+    }
+
+    private HttpStatus mapToHttpStatus(ErrorCode code) {
+        return switch (code) {
+            case DM_NOT_FOUND, FEED_NOT_FOUND -> HttpStatus.NOT_FOUND;
+            case INVALID_REQUEST -> HttpStatus.BAD_REQUEST;
+            case INTERNAL_ERROR -> HttpStatus.INTERNAL_SERVER_ERROR;
+        };
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number


---

## 🪐 작업 내용

- 기존의 코드잇 `discodeit` 프로젝트에서 사용하던 **예외 처리 구조를 기준으로 공통 예외 클래스들을 정의**했습니다.
- 모든 도메인 예외는 `ClosetException`을 상속하여 구현할 수 있도록 구조화했습니다.
- 전역 예외 처리 클래스 `GlobalExceptionHandler`를 통해 `ClosetException` 및 일반 예외를 분기 처리합니다.
- `GlobalExceptionHandler`의 `mapToHttpStatus()` 메서드에서 `ErrorCode`에 따라 **적절한 HTTP 상태 코드로 매핑**되며, 새로운 에러 코드를 추가할 때는 아래처럼 switch 구문에 **직접 추가해야 합니다**.

```java
private HttpStatus mapToHttpStatus(ErrorCode code) {
    return switch (code) {
        case DM_NOT_FOUND, FEED_NOT_FOUND -> HttpStatus.NOT_FOUND;
        case INVALID_REQUEST -> HttpStatus.BAD_REQUEST;
        case INTERNAL_ERROR -> HttpStatus.INTERNAL_SERVER_ERROR;
    };
}
```

---

## 📚 Reference


## ✅ Check List

- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요? (현재는 구조만 작성된 상태입니다)
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] `ErrorCode`를 추가했을 경우, `mapToHttpStatus()`에 분기 추가를 누락하지 않았나요?
