### PR TITLE
Feat 피드 content 수정 기능 구현

### DIFF
--- a/src/main/java/project/closet/dto/response/FeedDto.java
+++ b/src/main/java/project/closet/dto/response/FeedDto.java
@@ -12,8 +12,8 @@ public record FeedDto(
         WeatherSummaryDto weather,
         List<OotdDto> ootds,
         String content,
-        int likeCount,
-        int commentCount,
+        long likeCount,
+        long commentCount,
         boolean likedByMe
 ) {
 

--- a/src/main/java/project/closet/exception/GlobalExceptionHandler.java
+++ b/src/main/java/project/closet/exception/GlobalExceptionHandler.java
@@ -43,7 +43,7 @@ public class GlobalExceptionHandler {
         return switch (code) {
             case DM_NOT_FOUND, FEED_NOT_FOUND, USER_NOT_FOUND, ATTRIBUTE_DEFINITION_NOT_FOUND ->
                     HttpStatus.NOT_FOUND;
-            case INVALID_REQUEST, ATTRIBUTE_DEFINITION_DUPLICATE, FEED_ALREADY_EXISTS -> HttpStatus.BAD_REQUEST;
+            case INVALID_REQUEST, ATTRIBUTE_DEFINITION_DUPLICATE, FEED_ALREADY_LIKE_EXISTS -> HttpStatus.BAD_REQUEST;
             case INVALID_TOKEN, TOKEN_NOT_FOUND, INVALID_TOKEN_SECRET -> HttpStatus.UNAUTHORIZED;
             case INTERNAL_ERROR -> HttpStatus.INTERNAL_SERVER_ERROR;
             default -> HttpStatus.INTERNAL_SERVER_ERROR;

--- a/src/main/java/project/closet/feed/controller/FeedController.java
+++ b/src/main/java/project/closet/feed/controller/FeedController.java
@@ -106,7 +106,8 @@ public class FeedController implements FeedApi {
     @DeleteMapping("/{feedId}")
     @Override
     public ResponseEntity<Void> deleteFeed(@PathVariable("feedId") UUID feedId) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        feedService.deleteFeed(feedId);
+        return ResponseEntity.noContent().build();
     }
 
     @PatchMapping("/{feedId}")

--- a/src/main/java/project/closet/feed/controller/FeedController.java
+++ b/src/main/java/project/closet/feed/controller/FeedController.java
@@ -117,6 +117,8 @@ public class FeedController implements FeedApi {
             @RequestBody @Valid FeedUpdateRequest feedUpdateRequest,
             @AuthenticationPrincipal ClosetUserDetails closetUserDetails
     ) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        FeedDto feedDto = feedService.updateFeed(feedId, feedUpdateRequest,
+                closetUserDetails.getUserId());
+        return ResponseEntity.ok(feedDto);
     }
 }

--- a/src/main/java/project/closet/feed/controller/FeedController.java
+++ b/src/main/java/project/closet/feed/controller/FeedController.java
@@ -114,7 +114,8 @@ public class FeedController implements FeedApi {
     @Override
     public ResponseEntity<FeedDto> updateFeed(
             @PathVariable("feedId") UUID feedId,
-            @RequestBody @Valid FeedUpdateRequest feedUpdateRequest
+            @RequestBody @Valid FeedUpdateRequest feedUpdateRequest,
+            @AuthenticationPrincipal ClosetUserDetails closetUserDetails
     ) {
         throw new UnsupportedOperationException("Not yet implemented");
     }

--- a/src/main/java/project/closet/feed/controller/api/FeedApi.java
+++ b/src/main/java/project/closet/feed/controller/api/FeedApi.java
@@ -131,5 +131,6 @@ public interface FeedApi {
                     responseCode = "400", description = "피드 수정 실패"
             )
     })
-    ResponseEntity<FeedDto> updateFeed(UUID feedId, FeedUpdateRequest feedUpdateRequest);
+    ResponseEntity<FeedDto> updateFeed(UUID feedId, FeedUpdateRequest feedUpdateRequest,
+            ClosetUserDetails closetUserDetails);
 }

--- a/src/main/java/project/closet/feed/entity/Feed.java
+++ b/src/main/java/project/closet/feed/entity/Feed.java
@@ -48,4 +48,11 @@ public class Feed extends BaseUpdatableEntity {
         FeedClothes feedClothes = new FeedClothes(this, clothes);
         this.feedClothesList.add(feedClothes);
     }
+
+    public void updateContent(String content) {
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("Content cannot be null or blank");
+        }
+        this.content = content;
+    }
 }

--- a/src/main/java/project/closet/feed/entity/FeedLike.java
+++ b/src/main/java/project/closet/feed/entity/FeedLike.java
@@ -1,4 +1,4 @@
-package project.closet.follower.entity;
+package project.closet.feed.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -12,7 +12,6 @@ import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import project.closet.feed.entity.Feed;
 import project.closet.user.entity.User;
 
 @Getter

--- a/src/main/java/project/closet/feed/repository/FeedCommentRepository.java
+++ b/src/main/java/project/closet/feed/repository/FeedCommentRepository.java
@@ -2,8 +2,10 @@ package project.closet.feed.repository;
 
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import project.closet.feed.entity.Feed;
 import project.closet.feed.entity.FeedComment;
 
 public interface FeedCommentRepository extends JpaRepository<FeedComment, UUID> {
 
+    long countByFeed(Feed feed);
 }

--- a/src/main/java/project/closet/feed/repository/FeedLikeRepository.java
+++ b/src/main/java/project/closet/feed/repository/FeedLikeRepository.java
@@ -3,7 +3,7 @@ package project.closet.feed.repository;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import project.closet.feed.entity.Feed;
-import project.closet.follower.entity.FeedLike;
+import project.closet.feed.entity.FeedLike;
 import project.closet.user.entity.User;
 
 public interface FeedLikeRepository extends JpaRepository<FeedLike, UUID> {
@@ -11,6 +11,10 @@ public interface FeedLikeRepository extends JpaRepository<FeedLike, UUID> {
     boolean existsByUserAndFeed(User user, Feed feed);
 
     void deleteByUserAndFeed(User user, Feed feed);
+
+    long countByFeed(Feed feed);
+
+    boolean existsByFeedIdAndUserId(UUID feedId, UUID userId);
 }
 
 /*

--- a/src/main/java/project/closet/feed/repository/FeedRepository.java
+++ b/src/main/java/project/closet/feed/repository/FeedRepository.java
@@ -1,9 +1,20 @@
 package project.closet.feed.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import project.closet.feed.entity.Feed;
 
 public interface FeedRepository extends JpaRepository<Feed, UUID> {
 
+    @Query("""
+                SELECT f FROM Feed f
+                JOIN FETCH f.author
+                JOIN FETCH f.weather
+                LEFT JOIN FETCH f.feedClothesList fc
+                LEFT JOIN FETCH fc.clothes
+                WHERE f.id = :feedId
+            """)
+    Optional<Feed> findByIdWithAll(UUID feedId);
 }

--- a/src/main/java/project/closet/feed/service/FeedService.java
+++ b/src/main/java/project/closet/feed/service/FeedService.java
@@ -3,6 +3,7 @@ package project.closet.feed.service;
 import java.util.UUID;
 import project.closet.dto.request.CommentCreateRequest;
 import project.closet.dto.request.FeedCreateRequest;
+import project.closet.dto.request.FeedUpdateRequest;
 import project.closet.dto.response.CommentDto;
 import project.closet.dto.response.FeedDto;
 
@@ -17,4 +18,6 @@ public interface FeedService {
     CommentDto createComment(CommentCreateRequest commentCreateRequest);
 
     void deleteFeed(UUID feedId);
+
+    FeedDto updateFeed(UUID feedId, FeedUpdateRequest feedUpdateRequest, UUID loginUserId);
 }

--- a/src/main/java/project/closet/feed/service/FeedService.java
+++ b/src/main/java/project/closet/feed/service/FeedService.java
@@ -15,4 +15,6 @@ public interface FeedService {
     void cancelFeedLike(UUID feedId, UUID userId);
 
     CommentDto createComment(CommentCreateRequest commentCreateRequest);
+
+    void deleteFeed(UUID feedId);
 }

--- a/src/main/java/project/closet/feed/service/basic/BasicFeedService.java
+++ b/src/main/java/project/closet/feed/service/basic/BasicFeedService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.closet.domain.clothes.repository.ClothesRepository;
@@ -123,5 +124,11 @@ public class BasicFeedService implements FeedService {
         FeedComment feedComment = new FeedComment(feed, author, commentCreateRequest.content());
         feedCommentRepository.save(feedComment);
         return CommentDto.from(feedComment);
+    }
+
+    @Transactional
+    @Override
+    public void deleteFeed(UUID feedId) {
+        feedRepository.deleteById(feedId);
     }
 }

--- a/src/main/java/project/closet/feed/service/basic/BasicFeedService.java
+++ b/src/main/java/project/closet/feed/service/basic/BasicFeedService.java
@@ -4,12 +4,13 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import project.closet.domain.clothes.entity.Clothes;
 import project.closet.domain.clothes.repository.ClothesRepository;
 import project.closet.dto.request.CommentCreateRequest;
 import project.closet.dto.request.FeedCreateRequest;
+import project.closet.dto.request.FeedUpdateRequest;
 import project.closet.dto.response.CommentDto;
 import project.closet.dto.response.FeedDto;
 import project.closet.dto.response.OotdDto;
@@ -22,11 +23,11 @@ import project.closet.exception.weather.WeatherNotFoundException;
 import project.closet.feed.entity.Feed;
 import project.closet.feed.entity.FeedClothes;
 import project.closet.feed.entity.FeedComment;
+import project.closet.feed.entity.FeedLike;
 import project.closet.feed.repository.FeedCommentRepository;
 import project.closet.feed.repository.FeedLikeRepository;
 import project.closet.feed.repository.FeedRepository;
 import project.closet.feed.service.FeedService;
-import project.closet.follower.entity.FeedLike;
 import project.closet.user.entity.User;
 import project.closet.user.repository.UserRepository;
 import project.closet.weather.entity.Weather;
@@ -67,19 +68,7 @@ public class BasicFeedService implements FeedService {
                 .map(OotdDto::from)
                 .toList();
 
-        FeedDto feedDto = new FeedDto(
-                feed.getId(),
-                feed.getCreatedAt(),
-                feed.getUpdatedAt(),
-                UserSummary.from(author),
-                WeatherSummaryDto.from(weather),
-                ootdDtos,
-                feed.getContent(),
-                0,
-                0,
-                false
-        );
-        return feedDto;
+        return toFeedDto(feed, 0, 0, false); // likeCount, commentCount는 초기값 0으로 설정
     }
 
     @Transactional
@@ -130,5 +119,46 @@ public class BasicFeedService implements FeedService {
     @Override
     public void deleteFeed(UUID feedId) {
         feedRepository.deleteById(feedId);
+    }
+
+    @Transactional
+    @Override
+    public FeedDto updateFeed(UUID feedId, FeedUpdateRequest feedUpdateRequest, UUID loginUserId) {
+        // Feed -> User, Weather, Clothes fetch join을 통해서 유저 정보도 함께 가져와야함
+        Feed feed = feedRepository.findByIdWithAll(feedId)
+                .orElseThrow(() -> FeedNotFoundException.withId(feedId));
+        feed.updateContent(feedUpdateRequest.content());
+
+        // like count 조회
+        long likeCount = feedLikeRepository.countByFeed(feed);
+        // comment count 조회
+        long commentCount = feedCommentRepository.countByFeed(feed);
+
+        List<OotdDto> ootdDtos = feed.getFeedClothesList().stream()
+                .map(feedClothes -> OotdDto.from(feedClothes.getClothes()))
+                .toList();
+
+        boolean likedByMe = feedLikeRepository.existsByFeedIdAndUserId(feedId, loginUserId);
+
+        return toFeedDto(feed, likeCount, commentCount, likedByMe); // likedByMe: false
+    }
+
+    private FeedDto toFeedDto(Feed feed, long likeCount, long commentCount, boolean likedByMe) {
+        List<OotdDto> ootdDtos = feed.getFeedClothesList().stream()
+                .map(feedClothes -> OotdDto.from(feedClothes.getClothes()))
+                .toList();
+
+        return new FeedDto(
+                feed.getId(),
+                feed.getCreatedAt(),
+                feed.getUpdatedAt(),
+                UserSummary.from(feed.getAuthor()),
+                WeatherSummaryDto.from(feed.getWeather()),
+                ootdDtos,
+                feed.getContent(),
+                likeCount,
+                commentCount,
+                likedByMe
+        );
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- 피드 안에 내용 업데이트 하는 기능 구현
- 피드 삭제 엔드포인트 구현 
- **피드 삭제와 업데이트는 API 상에는 있지만, 프론트에 기능이 아직 없음**
- 피드 Dto로 변환하는 로직 재사용을 위해서 서비스 레이어 내에 메소드 분리
## 📚 Reference

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
