### PR TITLE
Feat: 피드 댓글 조회 엔드포인트 기능 구현, Feed Service에 사용하지 않는 지역변수 삭제

### DIFF
--- a/src/main/java/project/closet/dto/response/CommentDtoCursorResponse.java
+++ b/src/main/java/project/closet/dto/response/CommentDtoCursorResponse.java
@@ -1,5 +1,17 @@
 package project.closet.dto.response;
 
-public record CommentDtoCursorResponse() {
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record CommentDtoCursorResponse(
+        List<CommentDto> data,
+        Instant nextCursor,
+        UUID nextIdAfter,
+        boolean hasNext,
+        long totalCount,
+        String sortBy,
+        String sortDirection
+) {
 
 }

--- a/src/main/java/project/closet/exception/GlobalExceptionHandler.java
+++ b/src/main/java/project/closet/exception/GlobalExceptionHandler.java
@@ -1,13 +1,35 @@
 package project.closet.exception;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        String name = ex.getName();
+        String value = ex.getValue() != null ? ex.getValue().toString() : "null";
+        String message = String.format("잘못된 요청 파라미터입니다: '%s' 값 '%s'는 유효하지 않습니다.", name, value);
+
+        Map<String, Object> details = new HashMap<>();
+        details.put("parameter", name);
+        details.put("invalidValue", value);
+
+        ErrorResponse response = new ErrorResponse(
+                ex.getClass().getSimpleName(),
+                message,
+                details,
+                HttpStatus.BAD_REQUEST.value()
+        );
+        return ResponseEntity.badRequest().body(response);
+    }
 
     //도메인에서 명시적으로 발생시킨 사용자 정의 예외
     @ExceptionHandler(ClosetException.class)

--- a/src/main/java/project/closet/feed/controller/FeedController.java
+++ b/src/main/java/project/closet/feed/controller/FeedController.java
@@ -1,6 +1,7 @@
 package project.closet.feed.controller;
 
 import jakarta.validation.Valid;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import project.closet.dto.request.CommentCreateRequest;
 import project.closet.dto.request.FeedCreateRequest;
@@ -86,11 +88,13 @@ public class FeedController implements FeedApi {
     @Override
     public ResponseEntity<CommentDtoCursorResponse> getFeedComments(
             @PathVariable("feedId") UUID feedId,
-            String cursor,
-            UUID idAfter,
-            int limit
+            @RequestParam(name = "cursor", required = false) Instant cursor,
+            @RequestParam(name = "idAfter", required = false) UUID idAfter,
+            @RequestParam(name = "limit", defaultValue = "20") int limit
     ) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        CommentDtoCursorResponse feedComments =
+                feedService.getFeedComments(feedId, cursor, idAfter, limit);
+        return ResponseEntity.ok(feedComments);
     }
 
     @PostMapping("/{feedId}/comments")

--- a/src/main/java/project/closet/feed/controller/api/FeedApi.java
+++ b/src/main/java/project/closet/feed/controller/api/FeedApi.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.Instant;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import project.closet.dto.request.CommentCreateRequest;
@@ -91,7 +92,7 @@ public interface FeedApi {
     })
     ResponseEntity<CommentDtoCursorResponse> getFeedComments(
             UUID feedId,
-            String cursor,
+            Instant cursor,
             UUID idAfter,
             int limit
     );

--- a/src/main/java/project/closet/feed/repository/FeedCommentRepository.java
+++ b/src/main/java/project/closet/feed/repository/FeedCommentRepository.java
@@ -5,7 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import project.closet.feed.entity.Feed;
 import project.closet.feed.entity.FeedComment;
 
-public interface FeedCommentRepository extends JpaRepository<FeedComment, UUID> {
+public interface FeedCommentRepository extends JpaRepository<FeedComment, UUID>, FeedCommentRepositoryCustom {
 
     long countByFeed(Feed feed);
+
+    long countByFeedId(UUID feedId);
 }

--- a/src/main/java/project/closet/feed/repository/FeedCommentRepositoryCustom.java
+++ b/src/main/java/project/closet/feed/repository/FeedCommentRepositoryCustom.java
@@ -1,0 +1,12 @@
+package project.closet.feed.repository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import project.closet.feed.entity.FeedComment;
+
+public interface FeedCommentRepositoryCustom {
+
+    List<FeedComment> findByFeedWithCursor(UUID feedId, Instant cursor, UUID idAfter, int limitPlusOne);
+
+}

--- a/src/main/java/project/closet/feed/repository/impl/FeedCommentRepositoryImpl.java
+++ b/src/main/java/project/closet/feed/repository/impl/FeedCommentRepositoryImpl.java
@@ -1,0 +1,47 @@
+package project.closet.feed.repository.impl;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import project.closet.feed.entity.FeedComment;
+import project.closet.feed.repository.FeedCommentRepositoryCustom;
+
+@RequiredArgsConstructor
+public class FeedCommentRepositoryImpl implements FeedCommentRepositoryCustom {
+
+    private final EntityManager em;
+
+    @Override
+    public List<FeedComment> findByFeedWithCursor(UUID feedId, Instant cursor, UUID idAfter, int limitPlusOne) {
+        StringBuilder jpql = new StringBuilder("""
+            SELECT c FROM FeedComment c
+            JOIN FETCH c.author
+            WHERE c.feed.id = :feedId
+        """);
+
+        if (cursor != null) {
+            jpql.append("""
+                AND (
+                    c.createdAt > :cursor OR
+                    (c.createdAt = :cursor AND c.id > :idAfter)
+                )
+            """);
+        }
+
+        jpql.append(" ORDER BY c.createdAt ASC, c.id ASC");
+
+        TypedQuery<FeedComment> query = em.createQuery(jpql.toString(), FeedComment.class)
+                .setParameter("feedId", feedId)
+                .setMaxResults(limitPlusOne);
+
+        if (cursor != null) {
+            query.setParameter("cursor", cursor);
+            query.setParameter("idAfter", idAfter);
+        }
+
+        return query.getResultList();
+    }
+}

--- a/src/main/java/project/closet/feed/service/FeedService.java
+++ b/src/main/java/project/closet/feed/service/FeedService.java
@@ -1,10 +1,12 @@
 package project.closet.feed.service;
 
+import java.time.Instant;
 import java.util.UUID;
 import project.closet.dto.request.CommentCreateRequest;
 import project.closet.dto.request.FeedCreateRequest;
 import project.closet.dto.request.FeedUpdateRequest;
 import project.closet.dto.response.CommentDto;
+import project.closet.dto.response.CommentDtoCursorResponse;
 import project.closet.dto.response.FeedDto;
 
 public interface FeedService {
@@ -20,4 +22,6 @@ public interface FeedService {
     void deleteFeed(UUID feedId);
 
     FeedDto updateFeed(UUID feedId, FeedUpdateRequest feedUpdateRequest, UUID loginUserId);
+
+    CommentDtoCursorResponse getFeedComments(UUID feedId, Instant cursor, UUID idAfter, int limit);
 }

--- a/src/main/java/project/closet/feed/service/basic/BasicFeedService.java
+++ b/src/main/java/project/closet/feed/service/basic/BasicFeedService.java
@@ -1,17 +1,19 @@
 package project.closet.feed.service.basic;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import project.closet.domain.clothes.entity.Clothes;
 import project.closet.domain.clothes.repository.ClothesRepository;
 import project.closet.dto.request.CommentCreateRequest;
 import project.closet.dto.request.FeedCreateRequest;
 import project.closet.dto.request.FeedUpdateRequest;
 import project.closet.dto.response.CommentDto;
+import project.closet.dto.response.CommentDtoCursorResponse;
 import project.closet.dto.response.FeedDto;
 import project.closet.dto.response.OotdDto;
 import project.closet.dto.response.UserSummary;
@@ -159,6 +161,51 @@ public class BasicFeedService implements FeedService {
                 likeCount,
                 commentCount,
                 likedByMe
+        );
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public CommentDtoCursorResponse getFeedComments(
+            UUID feedId,
+            Instant cursor,
+            UUID idAfter,
+            int limit
+    ) {
+        if (!feedRepository.existsById(feedId)) {
+            throw FeedNotFoundException.withId(feedId);
+        }
+
+        List<FeedComment> comments =
+                feedCommentRepository.findByFeedWithCursor(feedId, cursor, idAfter, limit + 1);
+
+        long totalCount = feedCommentRepository.countByFeedId(feedId);
+
+        boolean hasNext = comments.size() > limit;
+        List<FeedComment> result = comments.stream()
+                .limit(limit)
+                .toList();
+
+        Instant nextCursor = null;
+        UUID nextId = null;
+        if (!result.isEmpty()) {
+            FeedComment last = result.get(result.size() - 1);
+            nextCursor = last.getCreatedAt();
+            nextId = last.getId();
+        }
+
+        List<CommentDto> data = result.stream()
+                .map(CommentDto::from)
+                .toList();
+
+        return new CommentDtoCursorResponse(
+                data,
+                nextCursor,
+                nextId,
+                hasNext,
+                totalCount,
+                "createdAt",
+                "ASCENDING"
         );
     }
 }

--- a/src/main/java/project/closet/feed/service/basic/BasicFeedService.java
+++ b/src/main/java/project/closet/feed/service/basic/BasicFeedService.java
@@ -65,11 +65,6 @@ public class BasicFeedService implements FeedService {
 
         feedRepository.save(feed);
 
-        List<OotdDto> ootdDtos = feed.getFeedClothesList()
-                .stream().map(FeedClothes::getClothes)
-                .map(OotdDto::from)
-                .toList();
-
         return toFeedDto(feed, 0, 0, false); // likeCount, commentCount는 초기값 0으로 설정
     }
 
@@ -135,10 +130,6 @@ public class BasicFeedService implements FeedService {
         long likeCount = feedLikeRepository.countByFeed(feed);
         // comment count 조회
         long commentCount = feedCommentRepository.countByFeed(feed);
-
-        List<OotdDto> ootdDtos = feed.getFeedClothesList().stream()
-                .map(feedClothes -> OotdDto.from(feedClothes.getClothes()))
-                .toList();
 
         boolean likedByMe = feedLikeRepository.existsByFeedIdAndUserId(feedId, loginUserId);
 


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- 피드 댓글 조회 커서 페이지네이션 기능구현
- 댓글 조회 레포지터리 JPQL로 작성
- 기존 DTO로 변환하는 로직 내부로 변경한 의상 파싱 로직 포함하여 지역변수 ootds 변환로직 삭제
## 📚 Reference

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
