### PR TITLE
Feat Feed 도메인 조회 엔드포인트 구현- 커서 페이지네이션

### DIFF
--- a/src/main/java/project/closet/domain/clothes/entity/Clothes.java
+++ b/src/main/java/project/closet/domain/clothes/entity/Clothes.java
@@ -19,6 +19,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import org.hibernate.annotations.BatchSize;
 import project.closet.domain.base.BaseUpdatableEntity;
 import project.closet.user.entity.User;
 
@@ -48,6 +49,7 @@ public class Clothes extends BaseUpdatableEntity {
     @Column(name = "type", nullable = false, length = 50)
     private ClothesType type;
 
+    @BatchSize(size = 100)
     @OneToMany(
             mappedBy = "clothes",
             cascade = CascadeType.ALL,

--- a/src/main/java/project/closet/dto/response/CommentDtoCursorResponse.java
+++ b/src/main/java/project/closet/dto/response/CommentDtoCursorResponse.java
@@ -3,6 +3,7 @@ package project.closet.dto.response;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import org.hibernate.query.SortDirection;
 
 public record CommentDtoCursorResponse(
         List<CommentDto> data,
@@ -11,7 +12,7 @@ public record CommentDtoCursorResponse(
         boolean hasNext,
         long totalCount,
         String sortBy,
-        String sortDirection
+        SortDirection sortDirection
 ) {
 
 }

--- a/src/main/java/project/closet/dto/response/FeedDtoCursorResponse.java
+++ b/src/main/java/project/closet/dto/response/FeedDtoCursorResponse.java
@@ -1,13 +1,12 @@
 package project.closet.dto.response;
 
-import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.hibernate.query.SortDirection;
 
 public record FeedDtoCursorResponse(
         List<FeedDto> data,
-        Instant nextCursor,
+        String nextCursor,
         UUID nextIdAfter,
         boolean hasNext,
         long totalCount,

--- a/src/main/java/project/closet/dto/response/FeedDtoCursorResponse.java
+++ b/src/main/java/project/closet/dto/response/FeedDtoCursorResponse.java
@@ -1,5 +1,18 @@
 package project.closet.dto.response;
 
-public record FeedDtoCursorResponse() {
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.hibernate.query.SortDirection;
+
+public record FeedDtoCursorResponse(
+        List<FeedDto> data,
+        Instant nextCursor,
+        UUID nextIdAfter,
+        boolean hasNext,
+        long totalCount,
+        String sortBy,
+        SortDirection sortDirection
+) {
 
 }

--- a/src/main/java/project/closet/feed/controller/FeedController.java
+++ b/src/main/java/project/closet/feed/controller/FeedController.java
@@ -42,19 +42,20 @@ public class FeedController implements FeedApi {
     @GetMapping
     @Override
     public ResponseEntity<FeedDtoCursorResponse> getFeedList(
-            @RequestParam(name = "cursor", required = false) Instant cursor,
+            @RequestParam(name = "cursor", required = false) String cursor,
             @RequestParam(name = "idAfter", required = false) UUID idAfter,
             @RequestParam(name = "limit", defaultValue = "20") int limit,
-            @RequestParam(name = "sortBy") String sortBy,  // 좋아요
-            @RequestParam(name = "sortDirection") SortDirection sortDirection,   // 항상 DESCENDING 임
+            @RequestParam(name = "sortBy") String sortBy,  // likeCount, createdAt
+            @RequestParam(name = "sortDirection") SortDirection sortDirection,
             @RequestParam(name = "keywordLike", required = false) String keywordLike,
             @RequestParam(name = "skyStatusEqual", required = false) SkyStatus skyStatusEqual,
             @RequestParam(name = "precipitationType", required = false) PrecipitationType precipitationType,
-            @RequestParam(name = "authorIdEqual", required = false) UUID authorIdEqual
+            @RequestParam(name = "authorIdEqual", required = false) UUID authorIdEqual,
+            @AuthenticationPrincipal ClosetUserDetails closetUserDetails
     ) {
         FeedDtoCursorResponse feedList = feedService.getFeedList(
                 cursor, idAfter, limit, sortBy, sortDirection, keywordLike,
-                skyStatusEqual, precipitationType, authorIdEqual);
+                skyStatusEqual, precipitationType, authorIdEqual, closetUserDetails.getUserId());
         return ResponseEntity.ok(feedList);
     }
 

--- a/src/main/java/project/closet/feed/controller/FeedController.java
+++ b/src/main/java/project/closet/feed/controller/FeedController.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.query.SortDirection;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -41,17 +42,20 @@ public class FeedController implements FeedApi {
     @GetMapping
     @Override
     public ResponseEntity<FeedDtoCursorResponse> getFeedList(
-            String cursor,
-            UUID idAfter,
-            int limit,
-            String sortBy,
-            String sortDirection,
-            String keywordLike,
-            SkyStatus skyStatusEqual,
-            PrecipitationType precipitationTypeEqual,
-            UUID authorIdEqual
+            @RequestParam(name = "cursor", required = false) Instant cursor,
+            @RequestParam(name = "idAfter", required = false) UUID idAfter,
+            @RequestParam(name = "limit", defaultValue = "20") int limit,
+            @RequestParam(name = "sortBy") String sortBy,  // 좋아요
+            @RequestParam(name = "sortDirection") SortDirection sortDirection,   // 항상 DESCENDING 임
+            @RequestParam(name = "keywordLike", required = false) String keywordLike,
+            @RequestParam(name = "skyStatusEqual", required = false) SkyStatus skyStatusEqual,
+            @RequestParam(name = "precipitationType", required = false) PrecipitationType precipitationType,
+            @RequestParam(name = "authorIdEqual", required = false) UUID authorIdEqual
     ) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        FeedDtoCursorResponse feedList = feedService.getFeedList(
+                cursor, idAfter, limit, sortBy, sortDirection, keywordLike,
+                skyStatusEqual, precipitationType, authorIdEqual);
+        return ResponseEntity.ok(feedList);
     }
 
     @PostMapping

--- a/src/main/java/project/closet/feed/controller/api/FeedApi.java
+++ b/src/main/java/project/closet/feed/controller/api/FeedApi.java
@@ -34,7 +34,7 @@ public interface FeedApi {
             )
     })
     ResponseEntity<FeedDtoCursorResponse> getFeedList(
-            Instant cursor,
+            String cursor,
             UUID idAfter,
             int limit,
             String sortBy,
@@ -42,7 +42,8 @@ public interface FeedApi {
             String keywordLike,
             SkyStatus skyStatusEqual,
             PrecipitationType precipitationTypeEqual,
-            UUID authorIdEqual
+            UUID authorIdEqual,
+            @Parameter(hidden = true) ClosetUserDetails closetUserDetails
     );
 
     // 피드 등록
@@ -67,7 +68,8 @@ public interface FeedApi {
                     responseCode = "400", description = "피드 좋아요 실패"
             )
     })
-    ResponseEntity<Void> likeFeed(UUID feedId, ClosetUserDetails closetUserDetails);
+    ResponseEntity<Void> likeFeed(UUID feedId,
+            @Parameter(hidden = true) ClosetUserDetails closetUserDetails);
 
     // 피드 좋아요 취소
     @Operation(summary = "피드 좋아요 취소", description = "피드 좋아요 취소 API")
@@ -79,7 +81,9 @@ public interface FeedApi {
                     responseCode = "400", description = "피드 좋아요 취소 실패"
             )
     })
-    ResponseEntity<Void> cancelFeed(UUID feedId, ClosetUserDetails closetUserDetails);
+    ResponseEntity<Void> cancelFeed(UUID feedId,
+            @Parameter(hidden = true)
+            ClosetUserDetails closetUserDetails);
 
     // 피드 댓글 조회
     @Operation(summary = "피드 댓글 조회", description = "피드 댓글 조회 API")
@@ -133,6 +137,9 @@ public interface FeedApi {
                     responseCode = "400", description = "피드 수정 실패"
             )
     })
-    ResponseEntity<FeedDto> updateFeed(UUID feedId, FeedUpdateRequest feedUpdateRequest,
-            ClosetUserDetails closetUserDetails);
+    ResponseEntity<FeedDto> updateFeed(
+            UUID feedId,
+            FeedUpdateRequest feedUpdateRequest,
+            @Parameter(hidden = true) ClosetUserDetails closetUserDetails
+    );
 }

--- a/src/main/java/project/closet/feed/controller/api/FeedApi.java
+++ b/src/main/java/project/closet/feed/controller/api/FeedApi.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.Instant;
 import java.util.UUID;
+import org.hibernate.query.SortDirection;
 import org.springframework.http.ResponseEntity;
 import project.closet.dto.request.CommentCreateRequest;
 import project.closet.dto.request.FeedCreateRequest;
@@ -33,11 +34,11 @@ public interface FeedApi {
             )
     })
     ResponseEntity<FeedDtoCursorResponse> getFeedList(
-            String cursor,
+            Instant cursor,
             UUID idAfter,
             int limit,
             String sortBy,
-            String sortDirection,
+            SortDirection sortDirection,
             String keywordLike,
             SkyStatus skyStatusEqual,
             PrecipitationType precipitationTypeEqual,

--- a/src/main/java/project/closet/feed/entity/Feed.java
+++ b/src/main/java/project/closet/feed/entity/Feed.java
@@ -13,6 +13,7 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import project.closet.domain.base.BaseUpdatableEntity;
 import project.closet.domain.clothes.entity.Clothes;
 import project.closet.user.entity.User;
@@ -35,8 +36,12 @@ public class Feed extends BaseUpdatableEntity {
     @Column(name = "content", columnDefinition = "TEXT", nullable = false)
     private String content;
 
+    @BatchSize(size = 100)
     @OneToMany(mappedBy = "feed", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FeedClothes> feedClothesList = new ArrayList<>();
+
+    @Column(name = "like_count", nullable = false)
+    private int likeCount = 0;
 
     public Feed(User author, Weather weather, String content) {
         this.author = author;

--- a/src/main/java/project/closet/feed/repository/FeedCommentRepository.java
+++ b/src/main/java/project/closet/feed/repository/FeedCommentRepository.java
@@ -2,12 +2,10 @@ package project.closet.feed.repository;
 
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import project.closet.feed.entity.Feed;
 import project.closet.feed.entity.FeedComment;
 
-public interface FeedCommentRepository extends JpaRepository<FeedComment, UUID>, FeedCommentRepositoryCustom {
-
-    long countByFeed(Feed feed);
+public interface FeedCommentRepository extends JpaRepository<FeedComment, UUID>,
+        FeedCommentRepositoryCustom {
 
     long countByFeedId(UUID feedId);
 }

--- a/src/main/java/project/closet/feed/repository/FeedCommentRepositoryCustom.java
+++ b/src/main/java/project/closet/feed/repository/FeedCommentRepositoryCustom.java
@@ -7,6 +7,6 @@ import project.closet.feed.entity.FeedComment;
 
 public interface FeedCommentRepositoryCustom {
 
-    List<FeedComment> findByFeedWithCursor(UUID feedId, Instant cursor, UUID idAfter, int limitPlusOne);
+    List<FeedComment> findByFeedWithCursor(UUID feedId, Instant cursor, UUID idAfter, int limit);
 
 }

--- a/src/main/java/project/closet/feed/repository/FeedLikeRepository.java
+++ b/src/main/java/project/closet/feed/repository/FeedLikeRepository.java
@@ -14,7 +14,7 @@ public interface FeedLikeRepository extends JpaRepository<FeedLike, UUID> {
 
     long countByFeed(Feed feed);
 
-    boolean existsByFeedIdAndUserId(UUID feedId, UUID userId);
+    boolean existsByUserIdAndFeedId(UUID userId, UUID feedId);
 }
 
 /*

--- a/src/main/java/project/closet/feed/repository/FeedRepository.java
+++ b/src/main/java/project/closet/feed/repository/FeedRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import project.closet.feed.entity.Feed;
 
-public interface FeedRepository extends JpaRepository<Feed, UUID> {
+public interface FeedRepository extends JpaRepository<Feed, UUID>, FeedRepositoryCustom {
 
     @Query("""
                 SELECT f FROM Feed f

--- a/src/main/java/project/closet/feed/repository/FeedRepositoryCustom.java
+++ b/src/main/java/project/closet/feed/repository/FeedRepositoryCustom.java
@@ -1,0 +1,30 @@
+package project.closet.feed.repository;
+
+import java.util.List;
+import java.util.UUID;
+import org.hibernate.query.SortDirection;
+import project.closet.feed.entity.Feed;
+import project.closet.weather.entity.PrecipitationType;
+import project.closet.weather.entity.SkyStatus;
+
+public interface FeedRepositoryCustom {
+
+    List<Feed> findAllWithCursorAndFilters(
+            String cursor,
+            UUID idAfter,
+            int limit,
+            String sortBy,
+            SortDirection sortDirection,
+            String keywordLike,
+            SkyStatus skyStatusEqual,
+            PrecipitationType precipitationType,
+            UUID authorIdEqual
+    );
+
+    long countByFilters(
+            String keywordLike,
+            SkyStatus skyStatusEqual,
+            PrecipitationType precipitationType,
+            UUID authorIdEqual
+    );
+}

--- a/src/main/java/project/closet/feed/repository/impl/FeedCommentRepositoryImpl.java
+++ b/src/main/java/project/closet/feed/repository/impl/FeedCommentRepositoryImpl.java
@@ -15,20 +15,21 @@ public class FeedCommentRepositoryImpl implements FeedCommentRepositoryCustom {
     private final EntityManager em;
 
     @Override
-    public List<FeedComment> findByFeedWithCursor(UUID feedId, Instant cursor, UUID idAfter, int limit) {
+    public List<FeedComment> findByFeedWithCursor(UUID feedId, Instant cursor, UUID idAfter,
+            int limit) {
         StringBuilder jpql = new StringBuilder("""
-            SELECT c FROM FeedComment c
-            JOIN FETCH c.author
-            WHERE c.feed.id = :feedId
-        """);
+                    SELECT c FROM FeedComment c
+                    JOIN FETCH c.author
+                    WHERE c.feed.id = :feedId
+                """);
 
         if (cursor != null) {
             jpql.append("""
-                AND (
-                    c.createdAt > :cursor OR
-                    (c.createdAt = :cursor AND c.id > :idAfter)
-                )
-            """);
+                        AND (
+                            c.createdAt > :cursor OR
+                            (c.createdAt = :cursor AND c.id > :idAfter)
+                        )
+                    """);
         }
 
         jpql.append(" ORDER BY c.createdAt ASC, c.id ASC");

--- a/src/main/java/project/closet/feed/repository/impl/FeedCommentRepositoryImpl.java
+++ b/src/main/java/project/closet/feed/repository/impl/FeedCommentRepositoryImpl.java
@@ -15,7 +15,7 @@ public class FeedCommentRepositoryImpl implements FeedCommentRepositoryCustom {
     private final EntityManager em;
 
     @Override
-    public List<FeedComment> findByFeedWithCursor(UUID feedId, Instant cursor, UUID idAfter, int limitPlusOne) {
+    public List<FeedComment> findByFeedWithCursor(UUID feedId, Instant cursor, UUID idAfter, int limit) {
         StringBuilder jpql = new StringBuilder("""
             SELECT c FROM FeedComment c
             JOIN FETCH c.author
@@ -35,7 +35,7 @@ public class FeedCommentRepositoryImpl implements FeedCommentRepositoryCustom {
 
         TypedQuery<FeedComment> query = em.createQuery(jpql.toString(), FeedComment.class)
                 .setParameter("feedId", feedId)
-                .setMaxResults(limitPlusOne);
+                .setMaxResults(limit);
 
         if (cursor != null) {
             query.setParameter("cursor", cursor);

--- a/src/main/java/project/closet/feed/repository/impl/FeedCommentRepositoryImpl.java
+++ b/src/main/java/project/closet/feed/repository/impl/FeedCommentRepositoryImpl.java
@@ -15,8 +15,12 @@ public class FeedCommentRepositoryImpl implements FeedCommentRepositoryCustom {
     private final EntityManager em;
 
     @Override
-    public List<FeedComment> findByFeedWithCursor(UUID feedId, Instant cursor, UUID idAfter,
-            int limit) {
+    public List<FeedComment> findByFeedWithCursor(
+            UUID feedId,
+            Instant cursor,
+            UUID idAfter,
+            int limit
+    ) {
         StringBuilder jpql = new StringBuilder("""
                     SELECT c FROM FeedComment c
                     JOIN FETCH c.author

--- a/src/main/java/project/closet/feed/repository/impl/FeedRepositoryImpl.java
+++ b/src/main/java/project/closet/feed/repository/impl/FeedRepositoryImpl.java
@@ -89,8 +89,9 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
         }
 
         // 정렬 Order By
-        jpql.append("ORDER BY f.").append(sortBy).append(" ").append(sortDirection.name());
-        jpql.append(", f.id ").append(sortDirection.name());
+        jpql.append("ORDER BY f.")
+                .append(sortBy).append(" ").append(toJpaDirection(sortDirection))
+                .append(", f.id ").append(toJpaDirection(sortDirection));
 
         // 파라미터 매핑
         TypedQuery<Feed> query = em.createQuery(jpql.toString(), Feed.class);
@@ -135,5 +136,9 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
         TypedQuery<Long> query = em.createQuery(jqpl.toString(), Long.class);
         params.forEach(query::setParameter);
         return query.getSingleResult();
+    }
+
+    private String toJpaDirection(SortDirection direction) {
+        return direction == SortDirection.DESCENDING ? "DESC" : "ASC";
     }
 }

--- a/src/main/java/project/closet/feed/repository/impl/FeedRepositoryImpl.java
+++ b/src/main/java/project/closet/feed/repository/impl/FeedRepositoryImpl.java
@@ -57,35 +57,30 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
             jpql.append("AND a.id = :authorIdEqual ");
             params.put("authorIdEqual", authorIdEqual);
         }
-
-        switch (sortBy) {
-            case "createdAt" -> {
-                Instant parse = (cursor != null && !cursor.isBlank())
-                        ? Instant.parse(cursor) : null;
-                if (sortDirection == SortDirection.DESCENDING) {
+        if (cursor != null && !cursor.isBlank()) {
+            switch (sortBy) {
+                case "createdAt" -> {
+                    Instant parsed = Instant.parse(cursor);
                     jpql.append(
-                            "AND (f.createdAt < :cursor OR (f.createdAt = :cursor AND f.id < :idAfter)) ");
-                } else {
-                    jpql.append(
-                            "AND (f.createdAt > :cursor OR (f.createdAt = :cursor AND f.id > :idAfter)) ");
+                            sortDirection == SortDirection.DESCENDING ?
+                                    "AND (f.createdAt < :cursor OR (f.createdAt = :cursor AND f.id < :idAfter)) " :
+                                    "AND (f.createdAt > :cursor OR (f.createdAt = :cursor AND f.id > :idAfter)) "
+                    );
+                    params.put("cursor", parsed);
+                    params.put("idAfter", idAfter);
                 }
-                params.put("cursor", parse);
-                params.put("idAfter", idAfter);
-            }
-            case "likeCount" -> {
-                Integer parse = (cursor != null && !cursor.isBlank())
-                        ? Integer.parseInt(cursor) : null;
-                if (sortDirection == SortDirection.DESCENDING) {
+                case "likeCount" -> {
+                    Integer parsed = Integer.parseInt(cursor);
                     jpql.append(
-                            "AND (f.likeCount < :cursor OR (f.likeCount = :cursor AND f.id < :idAfter)) ");
-                } else {
-                    jpql.append(
-                            "AND (f.likeCount > :cursor OR (f.likeCount = :cursor AND f.id > :idAfter)) ");
+                            sortDirection == SortDirection.DESCENDING ?
+                                    "AND (f.likeCount < :cursor OR (f.likeCount = :cursor AND f.id < :idAfter)) " :
+                                    "AND (f.likeCount > :cursor OR (f.likeCount = :cursor AND f.id > :idAfter)) "
+                    );
+                    params.put("cursor", parsed);
+                    params.put("idAfter", idAfter);
                 }
-                params.put("cursor", parse);
-                params.put("idAfter", idAfter);
+                default -> throw new IllegalArgumentException("지원하지 않는 정렬 값입니다: " + sortBy);
             }
-            default -> throw new IllegalArgumentException("지원하지 않는 sortBy 값입니다: " + sortBy);
         }
 
         // 정렬 Order By

--- a/src/main/java/project/closet/feed/repository/impl/FeedRepositoryImpl.java
+++ b/src/main/java/project/closet/feed/repository/impl/FeedRepositoryImpl.java
@@ -1,0 +1,139 @@
+package project.closet.feed.repository.impl;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.query.SortDirection;
+import project.closet.feed.entity.Feed;
+import project.closet.feed.repository.FeedRepositoryCustom;
+import project.closet.weather.entity.PrecipitationType;
+import project.closet.weather.entity.SkyStatus;
+
+@RequiredArgsConstructor
+public class FeedRepositoryImpl implements FeedRepositoryCustom {
+
+    private final EntityManager em;
+
+    @Override
+    public List<Feed> findAllWithCursorAndFilters(
+            String cursor,
+            UUID idAfter,
+            int limit,
+            String sortBy,
+            SortDirection sortDirection,
+            String keywordLike,
+            SkyStatus skyStatusEqual,
+            PrecipitationType precipitationType,
+            UUID authorIdEqual
+    ) {
+        StringBuilder jpql = new StringBuilder("""
+                SELECT f FROM Feed f
+                JOIN FETCH f.author a
+                JOIN FETCH f.weather w
+                WHERE 1 = 1
+                """);
+
+        Map<String, Object> params = new HashMap<>();
+
+        // 필터 조건
+        if (keywordLike != null && !keywordLike.isBlank()) {
+            jpql.append("AND LOWER(f.content) LIKE LOWER(:keywordLike) ");
+            params.put("keywordLike", "%" + keywordLike + "%");
+        }
+        if (skyStatusEqual != null) {
+            jpql.append("AND w.skyStatus = :skyStatusEqual ");
+            params.put("skyStatusEqual", skyStatusEqual);
+        }
+        if (precipitationType != null) {
+            jpql.append("AND w.precipitationType = :precipitationType ");
+            params.put("precipitationType", precipitationType);
+        }
+        if (authorIdEqual != null) {
+            jpql.append("AND a.id = :authorIdEqual ");
+            params.put("authorIdEqual", authorIdEqual);
+        }
+
+        switch (sortBy) {
+            case "createdAt" -> {
+                Instant parse = (cursor != null && !cursor.isBlank())
+                        ? Instant.parse(cursor) : null;
+                if (sortDirection == SortDirection.DESCENDING) {
+                    jpql.append(
+                            "AND (f.createdAt < :cursor OR (f.createdAt = :cursor AND f.id < :idAfter)) ");
+                } else {
+                    jpql.append(
+                            "AND (f.createdAt > :cursor OR (f.createdAt = :cursor AND f.id > :idAfter)) ");
+                }
+                params.put("cursor", parse);
+                params.put("idAfter", idAfter);
+            }
+            case "likeCount" -> {
+                Integer parse = (cursor != null && !cursor.isBlank())
+                        ? Integer.parseInt(cursor) : null;
+                if (sortDirection == SortDirection.DESCENDING) {
+                    jpql.append(
+                            "AND (f.likeCount < :cursor OR (f.likeCount = :cursor AND f.id < :idAfter)) ");
+                } else {
+                    jpql.append(
+                            "AND (f.likeCount > :cursor OR (f.likeCount = :cursor AND f.id > :idAfter)) ");
+                }
+                params.put("cursor", parse);
+                params.put("idAfter", idAfter);
+            }
+            default -> throw new IllegalArgumentException("지원하지 않는 sortBy 값입니다: " + sortBy);
+        }
+
+        // 정렬 Order By
+        jpql.append("ORDER BY f.").append(sortBy).append(" ").append(sortDirection.name());
+        jpql.append(", f.id ").append(sortDirection.name());
+
+        // 파라미터 매핑
+        TypedQuery<Feed> query = em.createQuery(jpql.toString(), Feed.class);
+        params.forEach(query::setParameter);
+        query.setMaxResults(limit + 1);
+
+        return query.getResultList();
+    }
+
+    @Override
+    public long countByFilters(String keywordLike, SkyStatus skyStatusEqual,
+            PrecipitationType precipitationType, UUID authorIdEqual) {
+        StringBuilder jqpl = new StringBuilder("""
+                SELECT COUNT(f) FROM Feed f
+                JOIN f.weather w
+                JOIN f.author a
+                WHERE 1 = 1
+                """);
+
+        Map<String, Object> params = new HashMap<>();
+
+        if (keywordLike != null && !keywordLike.isBlank()) {
+            jqpl.append("AND LOWER(f.content) LIKE LOWER(:keywordLike) ");
+            params.put("keywordLike", "%" + keywordLike + "%");
+        }
+
+        if (skyStatusEqual != null) {
+            jqpl.append("AND w.skyStatus = :skyStatusEqual ");
+            params.put("skyStatusEqual", skyStatusEqual);
+        }
+
+        if (precipitationType != null) {
+            jqpl.append("AND w.precipitationType = :precipitationType ");
+            params.put("precipitationType", precipitationType);
+        }
+
+        if (authorIdEqual != null) {
+            jqpl.append("AND a.id = :authorIdEqual ");
+            params.put("authorIdEqual", authorIdEqual);
+        }
+
+        TypedQuery<Long> query = em.createQuery(jqpl.toString(), Long.class);
+        params.forEach(query::setParameter);
+        return query.getSingleResult();
+    }
+}

--- a/src/main/java/project/closet/feed/repository/impl/FeedRepositoryImpl.java
+++ b/src/main/java/project/closet/feed/repository/impl/FeedRepositoryImpl.java
@@ -99,7 +99,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
     @Override
     public long countByFilters(String keywordLike, SkyStatus skyStatusEqual,
             PrecipitationType precipitationType, UUID authorIdEqual) {
-        StringBuilder jqpl = new StringBuilder("""
+        StringBuilder jpql = new StringBuilder("""
                 SELECT COUNT(f) FROM Feed f
                 JOIN f.weather w
                 JOIN f.author a
@@ -109,26 +109,26 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
         Map<String, Object> params = new HashMap<>();
 
         if (keywordLike != null && !keywordLike.isBlank()) {
-            jqpl.append("AND LOWER(f.content) LIKE LOWER(:keywordLike) ");
+            jpql.append("AND LOWER(f.content) LIKE LOWER(:keywordLike) ");
             params.put("keywordLike", "%" + keywordLike + "%");
         }
 
         if (skyStatusEqual != null) {
-            jqpl.append("AND w.skyStatus = :skyStatusEqual ");
+            jpql.append("AND w.skyStatus = :skyStatusEqual ");
             params.put("skyStatusEqual", skyStatusEqual);
         }
 
         if (precipitationType != null) {
-            jqpl.append("AND w.precipitationType = :precipitationType ");
+            jpql.append("AND w.precipitationType = :precipitationType ");
             params.put("precipitationType", precipitationType);
         }
 
         if (authorIdEqual != null) {
-            jqpl.append("AND a.id = :authorIdEqual ");
+            jpql.append("AND a.id = :authorIdEqual ");
             params.put("authorIdEqual", authorIdEqual);
         }
 
-        TypedQuery<Long> query = em.createQuery(jqpl.toString(), Long.class);
+        TypedQuery<Long> query = em.createQuery(jpql.toString(), Long.class);
         params.forEach(query::setParameter);
         return query.getSingleResult();
     }

--- a/src/main/java/project/closet/feed/service/FeedService.java
+++ b/src/main/java/project/closet/feed/service/FeedService.java
@@ -30,7 +30,7 @@ public interface FeedService {
     CommentDtoCursorResponse getFeedComments(UUID feedId, Instant cursor, UUID idAfter, int limit);
 
     FeedDtoCursorResponse getFeedList(
-            Instant cursor,
+            String cursor,
             UUID idAfter,
             int limit,
             String sortBy,
@@ -38,6 +38,7 @@ public interface FeedService {
             String keywordLike,
             SkyStatus skyStatusEqual,
             PrecipitationType precipitationType,
-            UUID authorIdEqual
+            UUID authorIdEqual,
+            UUID loginUserId
     );
 }

--- a/src/main/java/project/closet/feed/service/FeedService.java
+++ b/src/main/java/project/closet/feed/service/FeedService.java
@@ -2,12 +2,16 @@ package project.closet.feed.service;
 
 import java.time.Instant;
 import java.util.UUID;
+import org.hibernate.query.SortDirection;
 import project.closet.dto.request.CommentCreateRequest;
 import project.closet.dto.request.FeedCreateRequest;
 import project.closet.dto.request.FeedUpdateRequest;
 import project.closet.dto.response.CommentDto;
 import project.closet.dto.response.CommentDtoCursorResponse;
 import project.closet.dto.response.FeedDto;
+import project.closet.dto.response.FeedDtoCursorResponse;
+import project.closet.weather.entity.PrecipitationType;
+import project.closet.weather.entity.SkyStatus;
 
 public interface FeedService {
 
@@ -24,4 +28,16 @@ public interface FeedService {
     FeedDto updateFeed(UUID feedId, FeedUpdateRequest feedUpdateRequest, UUID loginUserId);
 
     CommentDtoCursorResponse getFeedComments(UUID feedId, Instant cursor, UUID idAfter, int limit);
+
+    FeedDtoCursorResponse getFeedList(
+            Instant cursor,
+            UUID idAfter,
+            int limit,
+            String sortBy,
+            SortDirection sortDirection,
+            String keywordLike,
+            SkyStatus skyStatusEqual,
+            PrecipitationType precipitationType,
+            UUID authorIdEqual
+    );
 }

--- a/src/main/java/project/closet/feed/service/basic/BasicFeedService.java
+++ b/src/main/java/project/closet/feed/service/basic/BasicFeedService.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Sort.Direction;
+import org.hibernate.query.SortDirection;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.closet.domain.clothes.repository.ClothesRepository;
@@ -15,6 +15,7 @@ import project.closet.dto.request.FeedUpdateRequest;
 import project.closet.dto.response.CommentDto;
 import project.closet.dto.response.CommentDtoCursorResponse;
 import project.closet.dto.response.FeedDto;
+import project.closet.dto.response.FeedDtoCursorResponse;
 import project.closet.dto.response.OotdDto;
 import project.closet.dto.response.UserSummary;
 import project.closet.dto.response.WeatherSummaryDto;
@@ -23,7 +24,6 @@ import project.closet.exception.feed.FeedNotFoundException;
 import project.closet.exception.user.UserNotFoundException;
 import project.closet.exception.weather.WeatherNotFoundException;
 import project.closet.feed.entity.Feed;
-import project.closet.feed.entity.FeedClothes;
 import project.closet.feed.entity.FeedComment;
 import project.closet.feed.entity.FeedLike;
 import project.closet.feed.repository.FeedCommentRepository;
@@ -32,6 +32,8 @@ import project.closet.feed.repository.FeedRepository;
 import project.closet.feed.service.FeedService;
 import project.closet.user.entity.User;
 import project.closet.user.repository.UserRepository;
+import project.closet.weather.entity.PrecipitationType;
+import project.closet.weather.entity.SkyStatus;
 import project.closet.weather.entity.Weather;
 import project.closet.weather.repository.WeatherRepository;
 
@@ -196,7 +198,24 @@ public class BasicFeedService implements FeedService {
                 hasNext,
                 totalCount,
                 "createdAt",
-                "ASCENDING"
+                SortDirection.ASCENDING
         );
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public FeedDtoCursorResponse getFeedList(
+            Instant cursor, UUID idAfter, int limit, String sortBy,
+            SortDirection sortDirection, String keywordLike, SkyStatus skyStatusEqual,
+            PrecipitationType precipitationType, UUID authorIdEqual
+    ) {
+        // repository로부터 필터/정렬/커서 조건을 만족하는 Feed 목록 조회
+
+        // 전체 개수 조회 (필터 조건 적용된 총 count)
+
+        // hasNext, nextCursor, nextIdAfter 계산
+
+        //FeedDto 변환 (Feed → FeedDto: author, weather, clothes 포함)
+        return null;
     }
 }

--- a/src/main/java/project/closet/feed/service/basic/BasicFeedService.java
+++ b/src/main/java/project/closet/feed/service/basic/BasicFeedService.java
@@ -67,11 +67,11 @@ public class BasicFeedService implements FeedService {
 
         feedRepository.save(feed);
 
-        return toFeedDto(feed, feed.getLikeCount(), false);
+        return toFeedDto(feed, 0, false);
     }
 
 
-    // TODO : Feed Like Count 업데이트 구현해야함
+    // TODO : Feed Like Count 업데이트 구현해야함 + 1, -1
     @Transactional
     @Override
     public void likeFeed(UUID feedId, UUID userId) {
@@ -135,7 +135,8 @@ public class BasicFeedService implements FeedService {
 
         boolean likedByMe = feedLikeRepository.existsByUserIdAndFeedId(loginUserId, feedId);
 
-        return toFeedDto(feed, feed.getLikeCount(), likedByMe);
+        long commentCount = feedCommentRepository.countByFeedId(feed.getId());
+        return toFeedDto(feed, commentCount, likedByMe);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -72,7 +72,8 @@ CREATE TABLE feeds
     weather_id UUID                     NOT NULL,
     created_at TIMESTAMP with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    content    TEXT                     NOT NULL
+    content    TEXT                     NOT NULL,
+    like_count INTEGER NOT NULL DEFAULT 0,
 );
 
 -- 5. Feed Comments


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- Feed 조회 페이지네이션 기능 구현
- Like Count를 Feed 엔티티 내부에 컬럼 추가해서 좋아요 개수 정렬 기능 구현
- Like Count 업데이트 시에 Feed에 좋아요 업데이트 기능 구현해야함
## 📚 Reference

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
