### PR TITLE
Refactor: USer 권한 수정 엔드포인트 User 컨트롤러 도메인으로 수정

### DIFF
--- a/src/main/java/project/closet/auth/controller/AuthController.java
+++ b/src/main/java/project/closet/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package project.closet.auth.controller;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -10,14 +11,12 @@ import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import project.closet.auth.controller.api.AuthApi;
 import project.closet.auth.service.AuthService;
-import project.closet.dto.request.RoleUpdateRequest;
-import project.closet.dto.response.UserDto;
+import project.closet.dto.request.ResetPasswordRequest;
 import project.closet.security.jwt.JwtService;
 import project.closet.security.jwt.JwtSession;
 
@@ -63,13 +62,11 @@ public class AuthController implements AuthApi {
         return ResponseEntity.ok(jwtSession.getAccessToken());
     }
 
-    @PutMapping("role")
-    public ResponseEntity<UserDto> role(@RequestBody RoleUpdateRequest request) {
-        log.info("권한 수정 요청");
-        UserDto userDto = authService.updateRole(request);
-
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(userDto);
+    @PostMapping("reset-password")
+    @Override
+    public ResponseEntity<Void> resetPassword(
+            @RequestBody @Valid ResetPasswordRequest resetPasswordRequest
+    ) {
+        return null;
     }
 }

--- a/src/main/java/project/closet/auth/controller/api/AuthApi.java
+++ b/src/main/java/project/closet/auth/controller/api/AuthApi.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.web.csrf.CsrfToken;
+import project.closet.dto.request.ResetPasswordRequest;
 
 @Tag(name = "인증 관리", description = "인증 관련 API")
 public interface AuthApi {
@@ -50,4 +51,15 @@ public interface AuthApi {
             @Parameter(hidden = true) HttpServletResponse response
     );
 
+    // 비밀번호 초기화
+    @Operation(summary = "비밀번호 초기화", description = "임시 비밀번호로 초기화 후 이메일로 전송합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204", description = "비밀번호 초기화 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "잘못된 요청"
+            )
+    })
+    ResponseEntity<Void> resetPassword(ResetPasswordRequest resetPasswordRequest);
 }

--- a/src/main/java/project/closet/auth/service/AuthService.java
+++ b/src/main/java/project/closet/auth/service/AuthService.java
@@ -1,11 +1,7 @@
 package project.closet.auth.service;
 
-import project.closet.dto.request.RoleUpdateRequest;
-import project.closet.dto.response.UserDto;
-
 public interface AuthService {
 
     void initAdmin();
 
-    UserDto updateRole(RoleUpdateRequest request);
 }

--- a/src/main/java/project/closet/auth/service/basic/BasicAuthService.java
+++ b/src/main/java/project/closet/auth/service/basic/BasicAuthService.java
@@ -1,17 +1,12 @@
 package project.closet.auth.service.basic;
 
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import project.closet.auth.service.AuthService;
-import project.closet.dto.request.RoleUpdateRequest;
 import project.closet.dto.response.UserDto;
-import project.closet.exception.user.UserNotFoundException;
 import project.closet.security.jwt.JwtService;
 import project.closet.user.entity.Profile;
 import project.closet.user.entity.Role;
@@ -51,16 +46,4 @@ public class BasicAuthService implements AuthService {
         log.info("어드민 계정이 생성되었습니다: {}", adminDto);
     }
 
-    @PreAuthorize("hasRole('ADMIN')")
-    @Transactional
-    @Override
-    public UserDto updateRole(RoleUpdateRequest request) {
-        UUID userId = request.userId();
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> UserNotFoundException.withId(userId));
-        user.updateRole(request.newRole());
-
-        jwtService.invalidateJwtSession(user.getId());
-        return UserDto.from(user);
-    }
 }

--- a/src/main/java/project/closet/dto/request/ResetPasswordRequest.java
+++ b/src/main/java/project/closet/dto/request/ResetPasswordRequest.java
@@ -1,0 +1,12 @@
+package project.closet.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ResetPasswordRequest(
+        @Email
+        @NotBlank
+        String email
+) {
+
+}

--- a/src/main/java/project/closet/dto/request/UserRoleUpdateRequest.java
+++ b/src/main/java/project/closet/dto/request/UserRoleUpdateRequest.java
@@ -1,0 +1,11 @@
+package project.closet.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import project.closet.user.entity.Role;
+
+public record UserRoleUpdateRequest(
+        @NotNull
+        Role role
+) {
+
+}

--- a/src/main/java/project/closet/security/SecurityMatchers.java
+++ b/src/main/java/project/closet/security/SecurityMatchers.java
@@ -32,7 +32,10 @@ public abstract class SecurityMatchers {
     public static final RequestMatcher REFRESH =
             new AntPathRequestMatcher("/api/auth/refresh", HttpMethod.POST.name());
 
+    public static final RequestMatcher RESET_PASSWORD =
+            new AntPathRequestMatcher("/api/auth/reset-password", HttpMethod.POST.name());
+
     public static final RequestMatcher[] PUBLIC_MATCHERS = new RequestMatcher[]{
-            NON_API, GET_CSRF_TOKEN, SIGN_UP, LOGIN, ME, REFRESH, LOGOUT, TEST
+            NON_API, GET_CSRF_TOKEN, SIGN_UP, LOGIN, ME, REFRESH, LOGOUT, RESET_PASSWORD
     };
 }

--- a/src/main/java/project/closet/user/controller/UserController.java
+++ b/src/main/java/project/closet/user/controller/UserController.java
@@ -20,6 +20,7 @@ import project.closet.dto.request.ChangePasswordRequest;
 import project.closet.dto.request.ProfileUpdateRequest;
 import project.closet.dto.request.UserCreateRequest;
 import project.closet.dto.request.UserLockUpdateRequest;
+import project.closet.dto.request.UserRoleUpdateRequest;
 import project.closet.dto.response.PageResponse;
 import project.closet.dto.response.ProfileDto;
 import project.closet.dto.response.UserDto;
@@ -98,5 +99,19 @@ public class UserController implements UserApi {
     ) {
         new UnsupportedOperationException("Not yet implemented");
         return null;
+    }
+
+    @PostMapping("/{userId}/role")
+    @Override
+    public ResponseEntity<UserDto> updateRole(
+            @PathVariable(value = "userId") UUID userId,
+            @RequestBody @Valid UserRoleUpdateRequest userRoleUpdateRequest
+    ) {
+        log.info("권한 수정 요청");
+        UserDto userDto = userService.updateRole(userId, userRoleUpdateRequest);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(userDto);
     }
 }

--- a/src/main/java/project/closet/user/controller/api/UserApi.java
+++ b/src/main/java/project/closet/user/controller/api/UserApi.java
@@ -17,6 +17,7 @@ import project.closet.dto.request.ChangePasswordRequest;
 import project.closet.dto.request.ProfileUpdateRequest;
 import project.closet.dto.request.UserCreateRequest;
 import project.closet.dto.request.UserLockUpdateRequest;
+import project.closet.dto.request.UserRoleUpdateRequest;
 import project.closet.dto.response.PageResponse;
 import project.closet.dto.response.ProfileDto;
 import project.closet.dto.response.UserDto;
@@ -123,4 +124,15 @@ public interface UserApi {
             @Parameter(description = "잠금 상태") UserLockUpdateRequest request
     );
 
+    //  권한 수정
+    @Operation(summary = "권한 수정", description = "권한 수정 API")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "권한 수정 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "권한 수정 실패(사용자 없음)"
+            )
+    })
+    ResponseEntity<UserDto> updateRole(UUID userId, UserRoleUpdateRequest userRoleUpdateRequest);
 }

--- a/src/main/java/project/closet/user/service/UserService.java
+++ b/src/main/java/project/closet/user/service/UserService.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 import org.springframework.web.multipart.MultipartFile;
 import project.closet.dto.request.ProfileUpdateRequest;
 import project.closet.dto.request.UserCreateRequest;
+import project.closet.dto.request.UserRoleUpdateRequest;
 import project.closet.dto.response.ProfileDto;
 import project.closet.dto.response.UserDto;
 
@@ -18,4 +19,7 @@ public interface UserService {
     // 회원 정보 수정
     ProfileDto updateProfile(UUID userId, ProfileUpdateRequest profileUpdateRequest,
             MultipartFile profileImage);
+
+    // 권한 수정
+    UserDto updateRole(UUID userid, UserRoleUpdateRequest userRoleUpdateRequest);
 }


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- 기존 권한 수정 엔드포인트가 Auth 도메인에 있던 것을 프론트 스펙에 맞게 User 도메인으로 변경했습니다.
## 📚 Reference

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
