### PR TITLE
Fix: UserRepository email 조건 검색에 공백 없어 db 에러 수정

### DIFF
--- a/src/main/java/project/closet/user/repository/impl/UserRepositoryImpl.java
+++ b/src/main/java/project/closet/user/repository/impl/UserRepositoryImpl.java
@@ -29,7 +29,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
         Map<String, Object> params = new HashMap<>();
 
         if (StringUtils.hasText(emailLike)) {
-            jpql.append("AND u.email LIKE :emailLike");
+            jpql.append("AND u.email LIKE :emailLike ");
             params.put("emailLike", "%" + emailLike + "%");
         }
         if (roleEqual != null) {


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- JPQL, UserRepositoryImpl 에서 빈 공백이 없어서 디비 에러나는 부분 수정
## 📚 Reference

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
