### PR TITLE
Refactor 메시지 리스트 조회 시 동일한 유저 이미지 presigned url 캐싱해서 한번만 요청하도록 변경, 피드 좋아요 카운트 업데이트

### DIFF
--- a/src/main/java/project/closet/feed/entity/Feed.java
+++ b/src/main/java/project/closet/feed/entity/Feed.java
@@ -60,4 +60,15 @@ public class Feed extends BaseUpdatableEntity {
         }
         this.content = content;
     }
+
+    public void incrementLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decrementLikeCount() {
+        if (this.likeCount <= 0) {
+            throw new IllegalStateException("Like count cannot be negative");
+        }
+        this.likeCount--;
+    }
 }

--- a/src/main/java/project/closet/feed/service/basic/BasicFeedService.java
+++ b/src/main/java/project/closet/feed/service/basic/BasicFeedService.java
@@ -87,6 +87,7 @@ public class BasicFeedService implements FeedService {
         if (feedLikeRepository.existsByUserAndFeed(user, feed)) {
             throw FeedLikeAlreadyExistsException.of(userId, feedId);
         }
+        feed.incrementLikeCount();
 
         feedLikeRepository.save(new FeedLike(feed, user));
     }
@@ -102,6 +103,7 @@ public class BasicFeedService implements FeedService {
 
         feedLikeRepository.deleteByUserAndFeed(user, feed);
         // Like 취소 시에 알림이 필요하다면, int 반환 받아서 값이 1이면 알림 생성하도록 할 수 있음
+        feed.decrementLikeCount();
     }
 
     @Transactional


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- 메시지 조회 시, 동일 유저 메시지 크기만큼 여러번 presignedUrl 요청 하던 문제 캐싱을 이용해서 한 번만 요청해서 동일한 URL 반환
- Feed 좋아요, 좋아요 취소 시 테이블에 좋아요 수 count 업데이트 기능 추가
## 📚 Reference

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
