### PR TITLE
Refactor: 유저 프로필 이미지 업데이트 시 기존 key로 s3 버킷에서 삭제 후 업로드 로직 변경

### DIFF
--- a/src/main/java/project/closet/storage/S3ContentStorage.java
+++ b/src/main/java/project/closet/storage/S3ContentStorage.java
@@ -79,7 +79,7 @@ public class S3ContentStorage {
             s3Client.deleteObject(request);
         } catch (S3Exception e) {
             log.error("S3에 파일 삭제 실패: {}", e.getMessage());
-            throw new RuntimeException("S3에 파일 업로드 실패: " + key, e);
+            throw new RuntimeException("S3에 파일 삭제 실패: " + key, e);
         }
     }
 }

--- a/src/main/java/project/closet/storage/S3ContentStorage.java
+++ b/src/main/java/project/closet/storage/S3ContentStorage.java
@@ -10,8 +10,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
@@ -65,5 +67,19 @@ public class S3ContentStorage {
                 .build();
 
         return s3Presigner.presignGetObject(presignRequest).url().toString();
+    }
+
+    public void deleteByKey(String key) {
+        try {
+            DeleteObjectRequest request = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+
+            s3Client.deleteObject(request);
+        } catch (S3Exception e) {
+            log.error("S3에 파일 삭제 실패: {}", e.getMessage());
+            throw new RuntimeException("S3에 파일 업로드 실패: " + key, e);
+        }
     }
 }

--- a/src/main/java/project/closet/user/service/basic/BasicUserService.java
+++ b/src/main/java/project/closet/user/service/basic/BasicUserService.java
@@ -90,7 +90,7 @@ public class BasicUserService implements UserService {
         Optional.ofNullable(profileImage)
                 .map(image -> {
                     s3ContentStorage.deleteByKey(user.getProfile().getProfileImageKey());
-                    return s3ContentStorage.upload(profileImage);
+                    return s3ContentStorage.upload(image);
                 })
                 .ifPresent(user::updateProfileImageKey);
         return toProfileDto(user);

--- a/src/main/java/project/closet/user/service/basic/BasicUserService.java
+++ b/src/main/java/project/closet/user/service/basic/BasicUserService.java
@@ -88,7 +88,10 @@ public class BasicUserService implements UserService {
                 .orElseThrow(() -> UserNotFoundException.withId(userId));
         user.updateProfile(profileUpdateRequest);
         Optional.ofNullable(profileImage)
-                .map(s3ContentStorage::upload)
+                .map(image -> {
+                    s3ContentStorage.deleteByKey(user.getProfile().getProfileImageKey());
+                    return s3ContentStorage.upload(profileImage);
+                })
                 .ifPresent(user::updateProfileImageKey);
         return toProfileDto(user);
     }


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- 유저가 프로필 이미지를 업데이트할 경우에, 기존 key로 s3 버킷에 등록된 이미지 삭제 후 업로드 하도록 변경
## 📚 Reference

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
