### PR TITLE
Feat/noti 의상 속성 추가, 변경 시 알림 생성, sse 연결 유저 이벤트 푸시 기능 구현

### DIFF
--- a/src/main/java/project/closet/domain/clothes/entity/Attribute.java
+++ b/src/main/java/project/closet/domain/clothes/entity/Attribute.java
@@ -52,8 +52,11 @@ public class Attribute {
         setSelectableValues(values);
     }
 
-    public void setDefinitionName(String definitionName) {
-        this.definitionName = definitionName;
+    public void updateDefinitionName(String newDefinitionName) {
+        if (this.definitionName.equals(newDefinitionName)) {
+            return;
+        }
+        this.definitionName = newDefinitionName;
     }
 
     public void addSelectableValue(String value) {

--- a/src/main/java/project/closet/domain/clothes/service/AttributeServiceImpl.java
+++ b/src/main/java/project/closet/domain/clothes/service/AttributeServiceImpl.java
@@ -19,6 +19,7 @@ import project.closet.domain.clothes.dto.response.ClothesAttributeDefDtoCursorRe
 import project.closet.domain.clothes.entity.Attribute;
 import project.closet.domain.clothes.repository.AttributeRepository;
 import project.closet.event.ClothesAttributeCreatEvent;
+import project.closet.event.ClothesAttributeUpdateEvent;
 import project.closet.exception.clothes.attribute.AttributeDuplicateException;
 import project.closet.exception.clothes.attribute.AttributeNotFoundException;
 
@@ -54,23 +55,20 @@ public class AttributeServiceImpl implements AttributeService {
             UUID id,
             ClothesAttributeDefUpdateRequest req
     ) {
-        Attribute e = repo.findById(id)
-                .orElseThrow(
-                        () -> new AttributeNotFoundException(
-                                id.toString()
-                        )
-                );
-
-        if (!e.getDefinitionName().equals(req.name())
-                && repo.existsByDefinitionName(req.name())) {
+        if (repo.existsByDefinitionName(req.name())) {
             throw new AttributeDuplicateException();
         }
+        
+        Attribute attribute = repo.findById(id)
+                .orElseThrow(() -> new AttributeNotFoundException(id.toString()));
 
-        e.setDefinitionName(req.name());
-        e.setSelectableValues(req.selectableValues());
+        attribute.updateDefinitionName(req.name());
+        attribute.setSelectableValues(req.selectableValues());
 
         // 의상 속성 수정 시 알림 생성 이벤트 발생.
-        return ClothesAttributeDefDto.of(e);
+        eventPublisher.publishEvent(new ClothesAttributeUpdateEvent(attribute.getDefinitionName()));
+
+        return ClothesAttributeDefDto.of(attribute);
     }
 
     @Override

--- a/src/main/java/project/closet/domain/clothes/service/AttributeServiceImpl.java
+++ b/src/main/java/project/closet/domain/clothes/service/AttributeServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -17,6 +18,7 @@ import project.closet.domain.clothes.dto.response.ClothesAttributeDefDto;
 import project.closet.domain.clothes.dto.response.ClothesAttributeDefDtoCursorResponse;
 import project.closet.domain.clothes.entity.Attribute;
 import project.closet.domain.clothes.repository.AttributeRepository;
+import project.closet.event.ClothesAttributeCreatEvent;
 import project.closet.exception.clothes.attribute.AttributeDuplicateException;
 import project.closet.exception.clothes.attribute.AttributeNotFoundException;
 
@@ -25,6 +27,7 @@ import project.closet.exception.clothes.attribute.AttributeNotFoundException;
 public class AttributeServiceImpl implements AttributeService {
 
     private final AttributeRepository repo;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -39,6 +42,8 @@ public class AttributeServiceImpl implements AttributeService {
                 req.selectableValues()
         );
         repo.save(entity);
+        // 의상 속성 추가 시 알림 생성 이벤트 발생.
+        eventPublisher.publishEvent(new ClothesAttributeCreatEvent(entity.getDefinitionName()));
 
         return ClothesAttributeDefDto.of(entity);
     }
@@ -64,6 +69,7 @@ public class AttributeServiceImpl implements AttributeService {
         e.setDefinitionName(req.name());
         e.setSelectableValues(req.selectableValues());
 
+        // 의상 속성 수정 시 알림 생성 이벤트 발생.
         return ClothesAttributeDefDto.of(e);
     }
 

--- a/src/main/java/project/closet/dto/response/NotificationDto.java
+++ b/src/main/java/project/closet/dto/response/NotificationDto.java
@@ -14,11 +14,11 @@ public record NotificationDto(
         NotificationLevel level
 ) {
 
-    public NotificationDto(Notification notification, UUID receiverId) {
+    public NotificationDto(Notification notification) {
         this(
                 notification.getId(),
                 notification.getCreatedAt(),
-                receiverId,
+                notification.getReceiverId(),
                 notification.getTitle(),
                 notification.getContent(),
                 notification.getLevel()

--- a/src/main/java/project/closet/event/ClothesAttributeCreatEvent.java
+++ b/src/main/java/project/closet/event/ClothesAttributeCreatEvent.java
@@ -1,0 +1,7 @@
+package project.closet.event;
+
+public record ClothesAttributeCreatEvent(
+        String definitionName
+) {
+
+}

--- a/src/main/java/project/closet/event/ClothesAttributeUpdateEvent.java
+++ b/src/main/java/project/closet/event/ClothesAttributeUpdateEvent.java
@@ -1,0 +1,7 @@
+package project.closet.event;
+
+public record ClothesAttributeUpdateEvent(
+        String definitionName
+) {
+
+}

--- a/src/main/java/project/closet/event/listener/NotificationEventListener.java
+++ b/src/main/java/project/closet/event/listener/NotificationEventListener.java
@@ -7,6 +7,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+import project.closet.event.ClothesAttributeCreatEvent;
 import project.closet.event.RoleChangeEvent;
 import project.closet.notification.entity.NotificationLevel;
 import project.closet.notification.service.NotificationService;
@@ -38,6 +39,23 @@ public class NotificationEventListener {
             log.info("권한 변경 알림 이벤트 처리 완료: receiverId={}", userId);
         } catch (Exception e) {
             log.error("권한 변경 알림 이벤트 처리 실패: receiverId={}, error={}", userId, e.getMessage(), e);
+            throw e;    // Retryable 예외 발생시켜 재시도 로직 시도
+        }
+    }
+
+    @Async("eventTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(ClothesAttributeCreatEvent event) {
+        log.info("새로운 의상 속성 추가 알림 이벤트 처리 시작: definitionName={}", event.definitionName());
+        try {
+            notificationService.createForAllUsers(
+                    "새로운 의상 속성이 추가되었어요.",
+                    String.format("내 의상에 '%s' 속성을 추가해보세요.", event.definitionName()),
+                    NotificationLevel.INFO
+            );
+            log.info("새로운 의상 속성 추가 알림 이벤트 처리 완료");
+        } catch (Exception e) {
+            log.error("새로운 의상 속성 추가 알림 이벤트 처리 실패: error={}", e.getMessage(), e);
             throw e;    // Retryable 예외 발생시켜 재시도 로직 시도
         }
     }

--- a/src/main/java/project/closet/event/listener/SseHandler.java
+++ b/src/main/java/project/closet/event/listener/SseHandler.java
@@ -25,4 +25,5 @@ public class SseHandler {
         UUID userId = notification.receiverId();
         sseService.send(userId, EVENT_NAME, notification);
     }
+
 }

--- a/src/main/java/project/closet/notification/entity/Notification.java
+++ b/src/main/java/project/closet/notification/entity/Notification.java
@@ -8,6 +8,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,9 +22,8 @@ import project.closet.user.entity.User;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseEntity {
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "receiver_id", nullable = false)
-    private User receiver;
+    @Column(name = "receiver_id", columnDefinition = "uuid", nullable = false)
+    private UUID receiverId;
 
     @Column(name = "title", nullable = false, length = 50)
     private String title;
@@ -36,8 +36,8 @@ public class Notification extends BaseEntity {
     private NotificationLevel level;
 
     @Builder
-    public Notification(User receiver, String title, String content, NotificationLevel level) {
-        this.receiver = receiver;
+    public Notification(UUID receiverId, String title, String content, NotificationLevel level) {
+        this.receiverId = receiverId;
         this.title = title;
         this.content = content;
         this.level = level;

--- a/src/main/java/project/closet/notification/entity/Notification.java
+++ b/src/main/java/project/closet/notification/entity/Notification.java
@@ -4,9 +4,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -14,7 +11,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.closet.domain.base.BaseEntity;
-import project.closet.user.entity.User;
 
 @Entity
 @Table(name = "notifications")

--- a/src/main/java/project/closet/notification/service/NotificationService.java
+++ b/src/main/java/project/closet/notification/service/NotificationService.java
@@ -12,4 +12,6 @@ public interface NotificationService {
     void deleteNotification(UUID notificationId);
 
     void create(UUID receiverId, String title, String content, NotificationLevel level);
+
+    void createForAllUsers(String title, String content, NotificationLevel level);
 }

--- a/src/main/java/project/closet/sse/SseService.java
+++ b/src/main/java/project/closet/sse/SseService.java
@@ -90,4 +90,17 @@ public class SseService {
                     });
                 });
     }
+
+    public void broadcast(String eventName, Object data) {
+        SseMessage message = sseMessageRepository.save(SseMessage.createBroadcast(eventName, data));
+        Set<DataWithMediaType> event = message.toEvent();
+        sseEmitterRepository.findAll()
+                .forEach(sseEmitter -> {
+                    try {
+                        sseEmitter.send(event);
+                    } catch (IOException e) {
+                        log.error(e.getMessage(), e);
+                    }
+                });
+    }
 }

--- a/src/main/java/project/closet/user/repository/UserRepository.java
+++ b/src/main/java/project/closet/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package project.closet.user.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,4 +17,7 @@ public interface UserRepository extends JpaRepository<User, UUID>, UserRepositor
 
     @Query("SELECT u FROM User u JOIN FETCH u.profile WHERE u.id = :userId")
     Optional<User> findByIdWithProfile(UUID userId);
+
+    @Query("SELECT u.id FROM User u")
+    List<UUID> findAllIds();
 }

--- a/src/test/java/project/closet/user/repository/UserRepositoryTest.java
+++ b/src/test/java/project/closet/user/repository/UserRepositoryTest.java
@@ -1,0 +1,41 @@
+package project.closet.user.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import project.closet.user.entity.User;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@EnableJpaAuditing
+@ActiveProfiles("test")
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("findAllIds(): 저장된 모든 사용자 ID를 가져온다")
+    void findAllIds_returnsAllUserIds() {
+        // given: 두 개의 User 엔티티 저장
+        User user1 = new User("test1", "test@mail.com", "password");
+
+        User user2 = new User("test2", "test2@mail.com", "password2");
+        userRepository.saveAll(List.of(user1, user2));
+
+        // when: 모든 ID 조회
+        List<UUID> ids = userRepository.findAllIds();
+
+        // then: 저장한 두 개의 ID가 순서와 무관하게 포함되어야 한다
+        assertThat(ids)
+                .hasSize(2)
+                .containsExactlyInAnyOrder(user1.getId(), user2.getId());
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- 알림 엔티티 연관관계 User 에서 receiverId로 수정했습니다.
- 의상 속성 추가 시 알림이 생성되고, sse 이벤트 발행해서 연결되어있는 유저 클라이언트에 이벤트 푸시
- 의상 속성 변경 시 알림이 생성되고, sse 이벤트 발행해서 연결되어있는 유저 클라이언트에 이벤트 푸시
- 속성 업데이트 메소드 이름 변경 `setDefinitionName` -> `updateDefinitionName`, 기존 이름과 같을 경우 업데이트 안하고 **return**
## 📚 Reference

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
