### PR TITLE
Feat/deploy 배포 이미지 ECR 저장소에서 받도록 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 COPY gradle ./gradle
 COPY gradlew ./gradlew
 COPY build.gradle settings.gradle ./
+RUN chmod +x gradlew
 
 RUN ./gradlew build -x test --no-daemon || true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,7 @@ services:
       - ./nginx/ssl/server.crt:/etc/nginx/ssl/server.crt:ro
       - ./nginx/ssl/server.key:/etc/nginx/ssl/server.key:ro
   app:
-    image: closet:local
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: 592835403754.dkr.ecr.ap-northeast-2.amazonaws.com/ootd-closet:latest
     container_name: closet
     env_file:
       - .env

--- a/src/main/java/project/closet/dto/request/UserCreateRequest.java
+++ b/src/main/java/project/closet/dto/request/UserCreateRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 
 public record UserCreateRequest(
         @NotBlank(message = "사용자 이름은 필수입니다")
-        @Size(min = 3, max = 50, message = "사용자 이름은 3자 이상 50자 이하여야 합니다")
+        @Size(min = 2, max = 50, message = "사용자 이름은 3자 이상 50자 이하여야 합니다")
         String name,
 
         @NotBlank(message = "이메일은 필수입니다")

--- a/src/main/resources/static/password-reset.html
+++ b/src/main/resources/static/password-reset.html
@@ -37,7 +37,7 @@
   <p>비밀번호 재설정이 완료되어 임시 비밀번호를 발급해 드립니다.</p>
   <p>임시 비밀번호: <strong>${tempPassword}</strong></p>
   <p>로그인 후 반드시 비밀번호를 변경해주세요.</p>
-  <a href="https://closet.com/login"
+  <a href="https://daily-ootd.online"
      style="
      display:inline-block;
      padding:12px 24px;


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- ECR 에 저장된 이미지 사용하도록 docker-compose.yml 파일 수정
- Dockerfile에 권한 추가
- 이메일 전송 시 제공되는 url a 태그 도메인으로 변경
## 📚 Reference

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
