### PR TITLE
Refactor: 스케줄러 지역 시간대를 명시적으로 설정, 로깅 레벨 수정

### DIFF
--- a/src/main/java/project/closet/weather/service/basic/BasicWeatherService.java
+++ b/src/main/java/project/closet/weather/service/basic/BasicWeatherService.java
@@ -56,7 +56,7 @@ public class BasicWeatherService implements WeatherService {
         );
     }
 
-    @Scheduled(cron = "0 0 23 * * *")
+    @Scheduled(cron = "0 0 23 * * *", zone = "Asia/Seoul")
     public void fetchAndSaveWeatherForecast() {
         log.info("🌤️ 날씨 정보 처리 요청");
 

--- a/src/main/java/project/closet/weather/service/basic/WeatherDataParser.java
+++ b/src/main/java/project/closet/weather/service/basic/WeatherDataParser.java
@@ -62,7 +62,7 @@ public class WeatherDataParser {
 
             // ⚠️ TMN/TMX 데이터 없는 날짜 제외
             if (!minTempMap.containsKey(date) || !maxTempMap.containsKey(date)) {
-                log.warn("⏭️ TMN/TMX 누락 → {}일 데이터 생략", date);
+                log.debug("⏭️ TMN/TMX 누락 → {}일 데이터 생략", date);
                 continue;
             }
 


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- EC2 서버에서 스케줄러가 원하는 시간대에 동작하지 않는 문제가 있어 스케줄러가 서버 시간과 무관하게 한국 시간으로 시작할 수 있도록 명시적으로 타임존 설정
- 중요하지 않은 tmx 로깅 레벨을 debug로 수정
## 📚 Reference

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
