### PR TITLE
Refactor: JPQL FeedComment 필드 속성 변경

### DIFF
--- a/src/main/java/project/closet/feed/repository/impl/FeedCommentRepositoryImpl.java
+++ b/src/main/java/project/closet/feed/repository/impl/FeedCommentRepositoryImpl.java
@@ -36,7 +36,7 @@ public class FeedCommentRepositoryImpl implements FeedCommentRepositoryCustom {
                     """);
         }
 
-        jpql.append(" ORDER BY c.createdAt ASC, c.userId ASC");
+        jpql.append(" ORDER BY c.createdAt ASC, c.author.id ASC");
 
         TypedQuery<FeedComment> query = em.createQuery(jpql.toString(), FeedComment.class)
                 .setParameter("feedId", feedId)


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- FeedComment Entity와 맞지 않는 JPQL 속성 c.userId -> c.author.id 로 변경
## 📚 Reference

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
