### PR TITLE
fix(sse): 스택 트레이스 출력 억제 및 타임아웃 시 /error 포워딩

### DIFF
--- a/src/main/java/project/closet/config/SecurityConfig.java
+++ b/src/main/java/project/closet/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package project.closet.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.DispatcherType;
 import java.util.List;
 import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +14,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -38,6 +40,7 @@ import project.closet.user.entity.Role;
 @Slf4j
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
     @Bean
@@ -50,6 +53,7 @@ public class SecurityConfig {
                 .authenticationProvider(daoAuthenticationProvider)
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(SecurityMatchers.PUBLIC_MATCHERS).permitAll()
+                        .dispatcherTypeMatchers(DispatcherType.ASYNC, DispatcherType.ERROR).permitAll()
                         .anyRequest().hasRole(Role.USER.name())
                 )
                 .csrf(csrf ->

--- a/src/main/java/project/closet/exception/GlobalExceptionHandler.java
+++ b/src/main/java/project/closet/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.async.AsyncRequestTimeoutException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
@@ -88,6 +89,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(response);
+    }
+
+    // SSE stream 의 타임아웃은 무시만 하고 아무것도 리턴하지 않습니다.
+    @ExceptionHandler(AsyncRequestTimeoutException.class)
+    public void handleSseTimeout(AsyncRequestTimeoutException ex) {
+        // no-op: suppress the timeout exception, so GlobalExceptionHandler 에게 안 넘어감
+        log.debug("SSE request timed out: {}", ex.getMessage());
     }
 
     private HttpStatus mapToHttpStatus(ErrorCode code) {

--- a/src/main/java/project/closet/security/SecurityMatchers.java
+++ b/src/main/java/project/closet/security/SecurityMatchers.java
@@ -35,7 +35,10 @@ public abstract class SecurityMatchers {
     public static final RequestMatcher RESET_PASSWORD =
             new AntPathRequestMatcher("/api/auth/reset-password", HttpMethod.POST.name());
 
+    public static final RequestMatcher ERROR =
+            new AntPathRequestMatcher("/error");
+
     public static final RequestMatcher[] PUBLIC_MATCHERS = new RequestMatcher[]{
-            NON_API, GET_CSRF_TOKEN, SIGN_UP, LOGIN, ME, REFRESH, LOGOUT, RESET_PASSWORD
+            NON_API, GET_CSRF_TOKEN, SIGN_UP, LOGIN, ME, REFRESH, LOGOUT, RESET_PASSWORD, ERROR
     };
 }

--- a/src/main/java/project/closet/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/project/closet/security/jwt/JwtAuthenticationFilter.java
@@ -49,10 +49,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             } else {
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-                ErrorResponse errorResponse = new ErrorResponse(
-                        new JwtException(ErrorCode.INVALID_TOKEN,
-                                Map.of("accessToken", accessToken)),
-                        HttpServletResponse.SC_UNAUTHORIZED);
+                ErrorResponse errorResponse =
+                        new ErrorResponse(
+                                new JwtException(
+                                        ErrorCode.INVALID_TOKEN,
+                                        Map.of("accessToken", accessToken)
+                                ),
+                                HttpServletResponse.SC_UNAUTHORIZED
+                        );
                 response.setCharacterEncoding("UTF-8");
                 response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
             }

--- a/src/main/java/project/closet/sse/SseService.java
+++ b/src/main/java/project/closet/sse/SseService.java
@@ -34,10 +34,12 @@ public class SseService {
         sseEmitter.onTimeout(() -> {
             log.debug("SSE onTimeout");
             sseEmitterRepository.delete(receiverId, sseEmitter);
+            sseEmitter.complete();
         });
         sseEmitter.onError((ex) -> {
             log.debug("SSE onError");
             sseEmitterRepository.delete(receiverId, sseEmitter);
+            sseEmitter.completeWithError(ex);
         });
 
         sseEmitterRepository.save(receiverId, sseEmitter);


### PR DESCRIPTION
## 📋 Summary  
- Server-Sent Events 연결에서 타임아웃 발생 시 콘솔에 스택 트레이스가 찍히지 않도록 억제했습니다.  
## 🪐 작업 내용

## 📚 Reference

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
